### PR TITLE
Made some textual changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,17 @@
 # dsmr exporter
 
+dsmr exporter is a daemon that reads smart meter P1 data (dsmr) and converts it to an elastic search document.
 
-dsmr exporter is a daemon that reads smart meter  p1 data (dsmr) and converts it to a elastic search document.
-
-dsmr_exporter can read data from: 
-- multiple serial port's
+dsmr_exporter can read data from:
+- multiple serial ports
 - multiple esp8266's
 
-This software needs hardware to work.  To find out more about the supported hardware, check out `docs/hardware.md`
+This software needs hardware to work. To find out more about the supported hardware, check out [`docs/hardware.md`](docs/hardware.md).
 
 
-# installation
+# Installation
 
-## from source
+## From source
 
     sudo pip3 install pyserial
     sudo pip3 install elasticsearch
@@ -23,13 +22,13 @@ This software needs hardware to work.  To find out more about the supported hard
 TODO
 
      
-# using
+# Using
 
-this example reads data from the *ttyUSB0* serial port and export the data to host *192.168.0.103*
+This example reads data from the *ttyUSB0* serial port and exports the data to host *192.168.0.103*
 
      ./dsmr_exporter.py --serial /dev/ttyUSB0 --elastic-host 192.168.0.103
 
-- attention: your user needs read access to the serial device
+- Attention: Your user needs read access to the serial device
 
 
       export P1_SERIAL=/dev/ttyUSB0
@@ -38,13 +37,12 @@ this example reads data from the *ttyUSB0* serial port and export the data to ho
       ./dsmr_exporter.py
 
     
-this example uses environment variables to read its config:
+This example uses environment variables to read its config:
 - serial input on `/dev/ttyUSB0`
-- tcp host `10.0.0.16` on port `5678` and tcp host `172.16.0.2` on port `8898`
-- elastic search host on ip `192.168.0.103` on port `1234`
+- TCP host `10.0.0.16` on port `5678` and TCP host `172.16.0.2` on port `8898`
+- elastic search host on IP `192.168.0.103` and port `1234`
 
-
-## options
+## Options
 
 option                     |environment variable| default |
 ---------------------------|--------------------|----------
@@ -53,18 +51,21 @@ option                     |environment variable| default |
 `--elastic-host`           | `ELASTIC_HOST`     | localhost:9200
 `--elastic-index`          | `ELASTIC_INDEX`    | dsmr-%Y.%m
 
-# example dashboard
+
+# Example dashboard
 
 ![grafana dashboard](docs/dashboards/grafana_dashboard.png)
 
-there are is an example dashboard for **elasticserach** and one for **grafana**.  They are located under `docs/dashboards`.
-The grafana source name is **elasticsearch-dsmr**.  don't forget to create a datasource with that name (ore change the dashboard) 
+There is an example dashboard for **elasticserach** and one for **grafana**.  They are located under [`docs/dashboards`](docs/dashboards).
+The grafana source name is **elasticsearch-dsmr**. Don't forget to create a datasource with that name (or change the dashboard).
 
-# elasticsearch
 
-It is wise to create a rollup job or delete old dsmr indexes.  Or to buy more storage as time passes :)
+# Elasticsearch
 
-# reference
+It is wise to create a rollup job or delete old dsmr indexes. Or to buy more storage as time passes :)
+
+
+# Reference
 
 [dsmr standard document](https://www.netbeheernederland.nl/_upload/Files/Slimme_meter_15_a727fce1f1.pdf)
 

--- a/docs/dashboards/grafana_dashboard_nl.json
+++ b/docs/dashboards/grafana_dashboard_nl.json
@@ -387,7 +387,7 @@
       },
       "id": 14,
       "panels": [],
-      "title": "Volt & Ampére",
+      "title": "Volt & Ampère",
       "type": "row"
     },
     {
@@ -732,7 +732,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Ampére",
+      "title": "Ampère",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -893,7 +893,7 @@
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "total kWh used ☀️/ 🌙",
+          "title": "total kWh used ☀️/🌙",
           "tooltip": {
             "shared": true,
             "sort": 0,

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -1,48 +1,43 @@
+# Hardware
+## P1 port on a smart meter
 
-# hardware
-## p1 port on a smart meter
+Most smart meters have an S1 and a P1 port. dsmr exporter needs the P1 port.  
+In Belgium you need to activate the port, this can be done via https://mijn.fluvius.be/poortbeheer  
+This process differs per country, you should search the internet for your country.
 
-Most smart meters have a S1 and a P1 port.  dsmr exporter needs the P1 port.  
-In Belgium you need to activate the port, this can be done via https://mijn.fluvius.be/poortbeheer
-This process differs per country, you should search the internet for you country.  
-
-The P1 port delivers +5V (maximum load 250mA).  Here is a pinout of the port, from the datasheet:
+The P1 port delivers +5V (maximum load 250mA). Here is a pinout of the port, from the datasheet:
 ![p1 connector](p1_rj12_connector.png)
 
 
-## serial 
-- Ready made cable's are available online.
+## Serial
 
-  these cable's have an built-in ttl inverter for pin 5, an don't need any soldering:
+- Ready-made cables are available online.  
+  These cables have a built-in TTL inverter for pin 5, and don't need any soldering:
     - [aliexpress](https://nl.aliexpress.com/item/32945187155.html) 
     - [search](https://duckduckgo.com/?q=dsmr+p1+cable)  
 
-
--  self made made cable
-
-  for this you need a serial ttl port.  Serial ttl ports come in many different forms:
-  
-  - rasberry pi
+- Self-made cable  
+  For this you need a serial TTL port, which come in many different forms:
+  - Rasberry Pi
   - microcontrollers
-  - usb to serial cables (example: [kiwi](https://www.kiwi-electronics.nl/usb-to-ttl-serial-kabel), [gotron](https://www.gotron.be/ft232-usb-naar-ttl-adapter-3-3-5v.html))      
+  - USB to serial cables (example: [kiwi](https://www.kiwi-electronics.nl/usb-to-ttl-serial-kabel), [gotron](https://www.gotron.be/ft232-usb-naar-ttl-adapter-3-3-5v.html))
 
-    next thing you need is a ttl inverter.
+    Next thing you need is a TTL inverter.
  
-    The data signal of a p1 port is inverted and standaard ttl serial won't understand the p1 signal.
-    a simple transistor inverter will do the job.      
-    
-    ![inverter](ttl_inverter.png) 
-    
-    - connect the RX output label to the rx of the usb ttl.
-    - connect ground RJ12 to the ground of the  inverter and the ground usb ttl.
-    - connect pin 1 (+5V) to pin 2 (DATA REQUEST), there is no need to connect the +5V pin to your ttl cable.
-    
+    The data signal of a P1 port is inverted and standard TTL serial won't understand the P1 signal.  
+    A simple transistor inverter will do the job:
 
-  In linux you can test the output of the serial port with a simple command:
+    ![inverter](ttl_inverter.png)
+
+    - Connect the RX output label to the RX of the USB TTL.
+    - Connect ground RJ12 to the ground of the inverter and the ground USB TTL.
+    - Connect pin 1 (+5V) to pin 2 (DATA REQUEST). There is no need to connect the +5V pin to your TTL cable.
+
+  In Linux you can test the output of the serial port with a simple command:
 
         screen /dev/ttyUSB0 115200
 
-  On Windows you can use [putty](https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html) to show the output of the serial port.
+  On Windows you can use [PuTTY](https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html) to show the output of the serial port.
 
   The output should look like this:
 
@@ -75,34 +70,31 @@ The P1 port delivers +5V (maximum load 250mA).  Here is a pinout of the port, fr
         !8AB2
         /FLU5\253769484_A
 
- 
 ## esp
 
-This requires some soldering.  I don't know any of the shelf hardware for this.
-You need: 
+This requires some soldering. I don't know any off-the-shelf hardware for this.  
+You need:
 - an [esp flasher](https://www.instructables.com/ESP-01-Programmer-Hack-the-Easy-One-/)
 - [RJ12 connector](https://www.reichelt.de/modular-stecker-rj12-kontakte-6-bestueckt-6-mp-6-6-p12707.html?CCOUNTRY=445&LANGUAGE=de&trstct=pos_12&nbc=1&&r=1) (you need a tool to use these connectors: [example](https://www.reichelt.de/crimpzange-fuer-modular-rj11-rj12-rj45-gb-77146-p293078.html?&trstct=pos_4&nbc=1) )
-- a [esp8266](https://en.wikipedia.org/wiki/ESP8266), example store: [gotron](https://www.gotron.be/catalogsearch/result/?q=ESP8266)
+- an [esp8266](https://en.wikipedia.org/wiki/ESP8266), example store: [gotron](https://www.gotron.be/catalogsearch/result/?q=ESP8266)
 - 3,3V LDO, example [az1117-3.3V](https://uk.farnell.com/diodes-inc/az1117d-3-3tre1/ldo-fixed-3-3v-1a-40-to-125deg/dp/3483077?st=az1117%203.3)
 - npn transistor [bc337](https://uk.farnell.com/search?st=bc337)
 - 2x 10 to 100µ F capacitor's (6,3V or more)
 - 2x 10K ohm resistor
 - 1x 1500 ohm resistor
-- some cable, I used old utp wires
+- some wires (I used the wires of an old UTP cable)
 
-The following diagram show's the rj12 and the power circuit.
-diagram:
+The following diagram shows the RJ12 and the power circuit:
 
 ![esp](esp+inverter.png)
-- connect the 3,3V to the Vcc of the esp
-- connect the GND to the GND of the esp
-- connect the RX of the transistor to the RX of the esp
+- Connect the 3,3V to the Vcc of the esp
+- Connect the GND to the GND of the esp
+- Connect the RX of the transistor to the RX of the esp
 - **connect the +3,3V to the CH_PD (this is the ENABLE pin)**
  
-Different firmware is available to create an serial to tcp server with an esp8266.  Wich one to choose is up you.
-Flashing and programming an esp is beyond the scope of this document.  Here are some pointers:
+Different firmware is available to create a serial to TCP server with an esp8266. Wich one to choose is up you.  
+Flashing and programming an esp is beyond the scope of this document. Here are some pointers:
 - [jeelabs](https://github.com/jeelabs/esp-link#serial-bridge)
-- [easy-esp](https://espeasy.readthedocs.io/en/latest/Reference/Flashing.html) and create a "serial server" 
+- [easy-esp](https://espeasy.readthedocs.io/en/latest/Reference/Flashing.html) and create a "serial server".
 
-good luck
-
+Good luck!

--- a/docs/p1 datatypes.md
+++ b/docs/p1 datatypes.md
@@ -2,7 +2,7 @@
 dsmr telegram data types
 =====
 
-electricity
+Electricity
 -----
 
 name                                                                       | key             | value
@@ -39,8 +39,8 @@ Instantaneous active power L3 (-P)                                         | 1-0
 
 
 
-gas
-----
+Gas
+-----
 
 
 

--- a/systemd/README.md
+++ b/systemd/README.md
@@ -1,11 +1,11 @@
 # systemd service
 
-you can use the `dsmr-exporter.service` file as a starting point.
+You can use the `dsmr-exporter.service` file as a starting point.
 
-change the `ExecStart=/usr/local/bin/dsmr_exporter.py` line to the path where you cloned dsmr-exporter.
+Change the `ExecStart=/usr/local/bin/dsmr_exporter.py` line to the path where you cloned dsmr-exporter.
 
 Don't forget to add the correct command line options.
 
 Example:
 
-    ExecStart=/home/username/bin/dsmr_exporter/dsmr_exporter.py --serial /dev/ttyUSB0 --elastic-host 192.168.0.103  
+    ExecStart=/home/username/bin/dsmr_exporter/dsmr_exporter.py --serial /dev/ttyUSB0 --elastic-host 192.168.0.103


### PR DESCRIPTION
For example:
- Removed double spaces between sentences
- Add more capitals at the start of sentences and for (technical) abbreviations.
- End some lines with a double space where more appropriate then adding an extra empty line to get a new-line.
- Renamed Ampére to Ampère (though for English Ampere would suffice)